### PR TITLE
Update DNGConverter to 10.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN winetricks settings win7
 
 COPY dngconverter /usr/local/bin
 # download links http://supportdownloads.adobe.com/product.jsp?product=106&platform=Windows
-ENV DNGVER=10_3
+ENV DNGVER=10_4
 RUN wget http://download.adobe.com/pub/adobe/dng/win/DNGConverter_${DNGVER}.exe && /usr/local/bin/dngconverter -i DNGConverter_${DNGVER}.exe && rm -f DNGConverter_${DNGVER}.exe
 
 # make wine silent

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 adobe-dngconverter-docker
 ====
 
-This image runs Adobe DNG Converter using Ubuntu and WINE.  Current version is 10.3.
+This image runs Adobe DNG Converter using Ubuntu and WINE.  Current version is 10.4.
 
 Instructions
 ---


### PR DESCRIPTION
Hi,

I was just about to build a Docker image that wraps the DNGConverter when I found yours. Thanks for sharing this!

I've updated the version to the latest release, which is 10.4 at the moment: https://supportdownloads.adobe.com/product.jsp?product=106&platform=Windows